### PR TITLE
feat: escaping single quote

### DIFF
--- a/indexer.py
+++ b/indexer.py
@@ -26,11 +26,11 @@ def indexDir(sqlDirectory: str, _engine: str) -> fileMap:
                 with open(fpath, encoding="utf-8") as f:
                     _fileMap[key].update({'fpath': fpath, 
                                         'category': root.removeprefix(sqlDirectory + '/'),
-                                        'query': f.read()})
+                                        'query': f.read().replace("'","''")})
             elif filename.endswith(".md") and filename.removesuffix(".md").lower()  not in ('readme', '.gitkeep'):
                 with open(fpath, encoding="utf-8") as f:
                     _fileMap[key].update({'docFPath': fpath,
-                                          'doc': f.read()})
+                                          'doc': f.read().replace("'","''")})
             else:
                 pass
 


### PR DESCRIPTION
- Escaping single quote in query and doc fields for avoiding json to break when unmarshalled.